### PR TITLE
fix: Remove embedded JSON dependency

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,11 +17,6 @@ buildscript {
 apply plugin: 'com.mparticle.kit'
 
 dependencies {
-    //TODO: Option 1: Replace with your Maven Central Dependency (preferred)
-    //compile 'com.example:example-artifact:1.2.3'
-
-    //TODO: Option 2: Include your jar in ./libs only if you're not in Maven Central
-    //TODO:           Please name the jar based on the version, ie AcmeSDK1234.jar
-    implementation fileTree(dir: 'libs', include: ['*.jar'])
+    testImplementation fileTree(dir: 'libs', include: ['*.jar'])
     compileOnly 'com.onetrust.cmp:native-sdk:+'
 }


### PR DESCRIPTION
# Summary

Remove embedded JSON dependency. This shouldn't have been packaged as a runtime dependency at all, `org.json` is available as part of the standard Android SDK 
