### PR TITLE
feat: SQDSKDS-4877 - Rebuiding state for individual GDPR consents for OneTrust

### DIFF
--- a/src/main/kotlin/com/mparticle/kits/OneTrustKit.kt
+++ b/src/main/kotlin/com/mparticle/kits/OneTrustKit.kt
@@ -11,6 +11,7 @@ import com.mparticle.consent.GDPRConsent
 import com.mparticle.identity.IdentityStateListener
 import com.mparticle.identity.MParticleUser
 import com.mparticle.internal.Logger
+import com.mparticle.kits.KitIntegration.IdentityListener
 import com.onetrust.otpublishers.headless.Public.Keys.OTBroadcastServiceKeys
 import com.onetrust.otpublishers.headless.Public.OTPublishersHeadlessSDK
 import com.onetrust.otpublishers.headless.Public.OTVendorListMode
@@ -19,7 +20,7 @@ import org.json.JSONException
 import org.json.JSONObject
 
 
-class OneTrustKit : KitIntegration(), IdentityStateListener {
+class OneTrustKit : KitIntegration(), IdentityStateListener, IdentityListener {
 
     internal enum class ConsentRegulation { GDPR, CCPA }
     internal class OneTrustConsent(val purpose: String, val regulation: ConsentRegulation)
@@ -299,7 +300,35 @@ class OneTrustKit : KitIntegration(), IdentityStateListener {
     }
 
     override fun onUserIdentified(user: MParticleUser, previousUser: MParticleUser?) {
+        processOneTrustConsents()
+    }
 
+    override fun onIdentifyCompleted(
+        mParticleUser: MParticleUser?,
+        identityApiRequest: FilteredIdentityApiRequest?
+    ) {
+    }
+
+    override fun onLoginCompleted(
+        mParticleUser: MParticleUser?,
+        identityApiRequest: FilteredIdentityApiRequest?
+    ) {
+    }
+
+    override fun onLogoutCompleted(
+        mParticleUser: MParticleUser?,
+        identityApiRequest: FilteredIdentityApiRequest?
+    ) {
+    }
+
+    override fun onModifyCompleted(
+        mParticleUser: MParticleUser?,
+        identityApiRequest: FilteredIdentityApiRequest?
+    ) {
+    }
+
+    override fun onUserIdentified(mParticleUser: MParticleUser?) {
+        processOneTrustConsents()
     }
 
 }

--- a/src/main/kotlin/com/mparticle/kits/OneTrustKit.kt
+++ b/src/main/kotlin/com/mparticle/kits/OneTrustKit.kt
@@ -20,7 +20,7 @@ import org.json.JSONException
 import org.json.JSONObject
 
 
-class OneTrustKit : KitIntegration(), IdentityStateListener, IdentityListener {
+class OneTrustKit : KitIntegration(), IdentityListener {
 
     internal enum class ConsentRegulation { GDPR, CCPA }
     internal class OneTrustConsent(val purpose: String, val regulation: ConsentRegulation)
@@ -297,10 +297,6 @@ class OneTrustKit : KitIntegration(), IdentityStateListener, IdentityListener {
         }
             .filterNotNull()
             .associate { it.first to it.second }
-    }
-
-    override fun onUserIdentified(user: MParticleUser, previousUser: MParticleUser?) {
-        processOneTrustConsents()
     }
 
     override fun onIdentifyCompleted(

--- a/src/test/kotlin/com/mparticle/kits/OneTrustKitTest.kt
+++ b/src/test/kotlin/com/mparticle/kits/OneTrustKitTest.kt
@@ -1,11 +1,19 @@
 package com.mparticle.kits
 
 import android.content.Context
+import com.mparticle.consent.CCPAConsent
+import com.mparticle.consent.ConsentState
+import com.mparticle.consent.GDPRConsent
+import com.mparticle.identity.MParticleUser
 import org.junit.Assert
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.mockito.Mockito
+import org.mockito.Mockito.`when`
 
 class KitTests {
     private val kit = OneTrustKit()
@@ -34,6 +42,51 @@ class KitTests {
             e = ex
         }
         Assert.assertNotNull(e)
+    }
+
+    /**
+     * This test should ensure that whatever the consent state is, if a new GDPR consent is created,
+     * it should be added to the consent state  GDPR map
+     */
+    @Test
+    fun testCreateConsentEventGDPR() {
+        val user = Mockito.mock(MParticleUser::class.java)
+        val gdprConsent = GDPRConsent.builder(false).build()
+        var currentConsentState =
+            ConsentState.builder().addGDPRConsentState("purpose1", gdprConsent).build()
+        `when`(user.consentState).thenReturn(currentConsentState)
+        assertEquals(1, currentConsentState.gdprConsentState.size)
+        assertEquals(gdprConsent, currentConsentState.gdprConsentState.get("purpose1"))
+        assertNull(currentConsentState.ccpaConsentState)
+        currentConsentState =
+            kit.createConsentEvent(user, "purpose2", 1, OneTrustKit.ConsentRegulation.GDPR)!!
+        assertEquals(2, currentConsentState.gdprConsentState.size)
+        assertEquals(gdprConsent, currentConsentState.gdprConsentState.get("purpose1"))
+        assertTrue(currentConsentState.gdprConsentState.containsKey("purpose2"))
+        assertEquals(true, currentConsentState.gdprConsentState.get("purpose2")!!.isConsented)
+        assertNull(currentConsentState.ccpaConsentState)
+    }
+
+    /**
+     * This test must ensure that any CCPA consent creates is added to the constent state.
+     * By design a new CCPA consent overrides the previous one.
+     */
+    @Test
+    fun testCreateConsentEventCCPA() {
+        val user = Mockito.mock(MParticleUser::class.java)
+        val ccpaConsent = CCPAConsent.builder(false).location("loc1").build()
+        var currentConsentState = ConsentState.builder().setCCPAConsentState(ccpaConsent).build()
+        `when`(user.consentState).thenReturn(currentConsentState)
+        assertEquals(0, currentConsentState.gdprConsentState.size)
+        assertEquals(ccpaConsent, currentConsentState.ccpaConsentState)
+        assertEquals("loc1", currentConsentState.ccpaConsentState?.location)
+        assertEquals(false, currentConsentState.ccpaConsentState?.isConsented)
+
+        currentConsentState =
+            kit.createConsentEvent(user, "ccpa", 1, OneTrustKit.ConsentRegulation.CCPA)!!
+        assertEquals(0, currentConsentState.gdprConsentState.size)
+        assertEquals(true, currentConsentState.ccpaConsentState?.isConsented)
+        assertNull(currentConsentState.ccpaConsentState?.location)
     }
 
     @Test


### PR DESCRIPTION
SQDSKDS-4877 - Rebuiding state for individual GDPR consents for OneTrust

## Instructions
 1. PR target branch should be against `development`
 2. PR title name should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-title-check.yml
 3. PR branch prefix should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-branch-check-name.yml

 ## Summary
 Adding changes to merge the current consent state with the individual consents selected on OneTrust.

Need to rebuild the overall consent state and re-set it to the MParticleUser, because the enable/disable actions for the individual GDPR consents are received one by one. Adding the corresponding tests.

 ## Testing Plan
 - [] Was this tested locally? If not, explain why.
 - Unit test created and checked logcat/livestream

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://mparticle-eng.atlassian.net/browse/SQDSDKS-4877
