### PR TITLE
fix: Correct Mapping Between OneTrust and mParticle

### DIFF
--- a/src/main/kotlin/com/mparticle/kits/OneTrustKit.kt
+++ b/src/main/kotlin/com/mparticle/kits/OneTrustKit.kt
@@ -106,9 +106,9 @@ class OneTrustKit : KitIntegration(), IdentityListener {
         val time = System.currentTimeMillis()
         MParticle.getInstance()?.Identity()?.currentUser?.let { user ->
             purposeConsentMapping.forEach { entry ->
-                val purpose = entry.key
+                val purpose = entry.value.purpose
                 val regulation = entry.value.regulation
-                val status = oneTrustSdk.getConsentStatusForGroupId(purpose)
+                val status = oneTrustSdk.getConsentStatusForGroupId(entry.key)
                 if (status != -1) {
                     createOrUpdateConsent(
                         user,


### PR DESCRIPTION
## Summary
 - mParticle was receiving Consent States with purposes matching OneTrust’s categories code (e.g.: c0002) rather than corresponding purposes set by the client in our UI. This change ensures that the correct key is being used.

 ## Testing Plan
 - Tested locally in emulator

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://go.mparticle.com/work/SQDSDKS-5270
