### PR TITLE
feat: Update to Support Unique OneTrust Versioning

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,16 @@ This repository contains the [OneTrust](https://www.onetrust.com) integration fo
     ```groovy
     dependencies {
         implementation 'com.mparticle:android-onetrust-kit:5+'
+    // Implement the SDK version that corresponds to the published version you're using'
+        implementation 'com.onetrust.cmp:native-sdk:X.X.0.0'
+
+    // Example: 
+        implementation 'com.onetrust.cmp:native-sdk:202308.1.0.0'
     }
+}
     ```
+    _Note: OneTrust is unique in their versioning and in that you must specify your version used from a constrained list in their UI. This necessitates that we cannot pin the version of the OneTrust SDK in this kit. Therefore you must pin the correct version in the build.gradle file of your application. For more information on this checkout this [OneTrust Guide for Adding the SDK to an Android App](https://developer.onetrust.com/onetrust/docs/adding-sdk-to-app-android)_
+    
 2. Follow the mParticle Android SDK [quick-start](https://github.com/mParticle/mparticle-android-sdk), then rebuild and launch your app, and verify that you see `"<REPLACE ME> detected"` in the output of `adb logcat`.
 3. Reference mParticle's integration docs below to enable the integration.
 

--- a/README.md
+++ b/README.md
@@ -11,10 +11,10 @@ This repository contains the [OneTrust](https://www.onetrust.com) integration fo
     ```groovy
     dependencies {
         implementation 'com.mparticle:android-onetrust-kit:5+'
-    // Implement the SDK version that corresponds to the published version you're using'
+        // Implement the SDK version that corresponds to the published version you're using'
         implementation 'com.onetrust.cmp:native-sdk:X.X.0.0'
 
-    // Example: 
+        // Example: 
         implementation 'com.onetrust.cmp:native-sdk:202308.1.0.0'
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -36,5 +36,5 @@ apply plugin: 'com.mparticle.kit'
 
 dependencies {
     testImplementation fileTree(dir: 'libs', include: ['*.jar'])
-    compileOnly 'com.onetrust.cmp:native-sdk:202308.2.0.0'
+    compileOnly 'com.onetrust.cmp:native-sdk:202308.+'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -36,5 +36,6 @@ apply plugin: 'com.mparticle.kit'
 
 dependencies {
     testImplementation fileTree(dir: 'libs', include: ['*.jar'])
-    compileOnly 'com.onetrust.cmp:native-sdk:202308.+'
+    //note that compileOnly requires kit users to define the dependency themselves
+    compileOnly 'com.onetrust.cmp:native-sdk:202308.2.0.0'
 }


### PR DESCRIPTION
## Summary
 - With OneTrust's unique versioning and requirements to set SDK from a constrained list in their UI the best solution seemed to be to unpin from any specific OneTrust version and update the README to warn users that the must set this themselves.

 ## Testing Plan
 - Tested using December release of OneTrust. Though this change doesn't change any functionality.

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://go.mparticle.com/work/SQDSDKS-5969
